### PR TITLE
Fix minor error in Rfast_lowerbound

### DIFF
--- a/src/binarysearch.cpp
+++ b/src/binarysearch.cpp
@@ -25,7 +25,7 @@ bool binarysearch(SEXP x,double v){
 }
 
 int lowerbound(SEXP x,double v){
-	bool res;
+	int res;
 	switch(TYPEOF(x)){
 		case INTSXP:{
 			int *start=INTEGER(x);


### PR DESCRIPTION
The data type of the return variable in `lowerbound` in
`src/binarysearch.cpp` was `bool` and not `int` as it should be.