### PR TITLE
Fix spurious warnings in data.frame.to_matrix

### DIFF
--- a/R/data.frame.to_matrix.R
+++ b/R/data.frame.to_matrix.R
@@ -3,10 +3,10 @@ data.frame.to_matrix <- function(x,col.names = NULL,row.names = NULL) {
 	if(is.null(col.names) && is.null(row.names)){
 		x <- .Call(Rfast_frame_to_matrix,x)
 	}else{
-		if(col.names == TRUE){
+		if(length(col.names) == 1 && col.names == TRUE){
 			col.names <- colnames(x)
 		}
-		if(row.names == TRUE){
+		if(length(row.names) == 1 && row.names == TRUE){
 			row.names <- rownames(x)
 		}
 		x <- .Call(Rfast_frame_to_matrix,x)


### PR DESCRIPTION
When a vector is supplied to row.names or col.names and warning is generated because of the if statement that checks for equality of that vector to TRUE. Adding the length check condition to the if statement prevents this.