### PR TITLE
Update multivariate_mle.R

### DIFF
--- a/R/multivariate_mle.R
+++ b/R/multivariate_mle.R
@@ -98,7 +98,7 @@ mvlnorm.mle <- function(x) {
   y <- Rfast::Log(x)  ## transform the data to the whole of R^d
   m1 <- Rfast::colmeans(y)  ## mean vector of y
   sigma <- crossprod(y)/n - tcrossprod(m1)
-  a <- n * d * log(2 * pi) + n * log(det(s)) + n * d - sum(y)
+  a <- n * d * log(2 * pi) + n * log(det(sigma)) + n * d - sum(y)
   
   s1 <- diag(sigma)
   m <- exp( m1 + 0.5 * s1 )  ## mean vector of x


### PR DESCRIPTION
**Describe the bug**
The function mvlnorm.mle always throws the error message Error in det(s) : object 's' not found

**To Reproduce**
1. A complete example with the same data that the function failed. (screenshots not preferred) x <- matrnorm(100, 4)
res<-mvlnorm.mle(x)
x <- NULL


**Suggested fix**

In multivariate_mle.R line 101 (https://github.com/RfastOfficial/Rfast/blob/1f14fbb7a0729b6c4122fc3ce12701ad4801f1a3/R/multivariate_mle.R#L101):

Instead of 
a <- n * d * log(2 * pi) + n * log(det(s)) + n * d - sum(y) Should be
a <- n * d * log(2 * pi) + n * log(det(sigma)) + n * d - sum(y)

s is the expected value, and not defined at that point in the code.

**Desktop (please complete the following information):**
 - OS: Windows 10 64-bit
 - R-Version 4.1.1
 - Rfast-Version 2.0.6