### PR TITLE
update - fix edist()

### DIFF
--- a/R/Dist.R
+++ b/R/Dist.R
@@ -26,7 +26,7 @@ edist <- function(x, y = NULL){
 	  dis <- matrix(0, p, p)
 	  ni <- numeric(p)
 	  for (i in 1:p) { 
-	    dii[i] <- Rfast::total.dist(x[[ i ]])
+	    dii[i] <- 2 * Rfast::total.dist(x[[ i ]])
 	    ni[i] <- dim(x[[ i ]])[1]  ## poses grammes exei
 	  }
 	  for ( i in 1:(p - 1) ) {


### PR DESCRIPTION
Rfast::total_dist() is summing over half of the distance matrix (and therefore total.dist(x) = total.dista(x, x) / 2). Note the Dist() function however works as intended.

I only change the code here since it's a issue for energy distance computation (as it was, the distance between a matrix and itself was not zero when using list() - but was ok if using x and y instead - because the c++ edist() function (src/energy.cpp, l114) already includes this correction). 

All the best
