### PR TITLE
Fix linking to RcppParallel libraries on Windows.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) `"${R_HOME}/bin/Rscript" -e "RcppParallel::LdFlags()"`
+PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(shell "${R_HOME}/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::LdFlags()")
 
 PKG_CXXFLAGS= $(SHLIB_OPENMP_CXXFLAGS)
 


### PR DESCRIPTION
This fixes a link failure on Windows due to accidental double quotes around the full path to RcppParallel, i.e.

```
cannot find -lRcppParallel: No such file or directory
```
as a result of 

```
-L"C:/r_packages/pkgbuild/lib/RcppParallel/libs/x64" -lRcppParallel
```
Generally, `$(shell)` is more reliable than backticks on Windows. 