### PR TITLE
Simplify Rfast_mahaCpp by removing redundant exception handling

### DIFF
--- a/src/maha_ex.cpp
+++ b/src/maha_ex.cpp
@@ -20,6 +20,6 @@ RcppExport SEXP Rfast_mahaCpp(SEXP XSEXP, SEXP muSEXP, SEXP sigmaSEXP, SEXP isCh
 
     arma::mat X_(X.begin(), X.nrow(), X.ncol(), false), sigma_(sigma.begin(), sigma.nrow(), sigma.ncol(), false);
     arma::vec mu_(mu.begin(), mu.size(), false);
-	return mahaInt(X_, mu_, sigma_, isChol);
+	return wrap(mahaInt(X_, mu_, sigma_, isChol));
 	END_RCPP
 }

--- a/src/maha_ex.cpp
+++ b/src/maha_ex.cpp
@@ -12,24 +12,14 @@ NumericVector mahaInt(arma::mat& X, arma::vec& mu, arma::mat& sigma, const bool 
  */
 RcppExport SEXP Rfast_mahaCpp(SEXP XSEXP, SEXP muSEXP, SEXP sigmaSEXP, SEXP isCholSEXP) {
 	BEGIN_RCPP
-	RObject __result = wrap(NA_REAL);
 	RNGScope __rngScope;
 	NumericMatrix X(XSEXP);
 	NumericVector mu(muSEXP);
 	NumericMatrix sigma(sigmaSEXP);
 	traits::input_parameter<bool>::type isChol(isCholSEXP);
 
-	try {
     arma::mat X_(X.begin(), X.nrow(), X.ncol(), false), sigma_(sigma.begin(), sigma.nrow(), sigma.ncol(), false);
     arma::vec mu_(mu.begin(), mu.size(), false);
-		NumericVector dist = mahaInt(X_, mu_, sigma_, isChol);
-		__result = dist;
-
-	} catch (std::exception& __ex__) {
-		forward_exception_to_r(__ex__);
-	} catch (...) {
-		::Rf_error("c++ exception (unknown reason)");
-	}
-	return __result;
+	return mahaInt(X_, mu_, sigma_, isChol);
 	END_RCPP
 }


### PR DESCRIPTION
The `BEGIN_RCPP` / `END_RCPP` macros already perform exception handling, so this PR removes the internal redundant one. Closes #136.